### PR TITLE
refactor(smooth-corners): improve rectangle support

### DIFF
--- a/static/posts/smooth-corners/paint.js
+++ b/static/posts/smooth-corners/paint.js
@@ -5,7 +5,7 @@ registerPaint('smooth-corners', class {
 
     superellipse(a, b, n) {
         const n2 = 2 / n
-        const steps = 64
+        const steps = 360
         const step = (2 * Math.PI) / steps
         const points = t => {
             const cosT = Math.cos(t)

--- a/static/posts/smooth-corners/paint.js
+++ b/static/posts/smooth-corners/paint.js
@@ -3,7 +3,7 @@ registerPaint('smooth-corners', class {
         return ['--smooth-corners']
     }
 
-    superecllipse(a, b, n) {
+    superellipse(a, b, n) {
         const n2 = 2 / n
         const steps = 64
         const step = (2 * Math.PI) / steps
@@ -26,7 +26,7 @@ registerPaint('smooth-corners', class {
 
         const width = geom.width / 2
         const height = geom.height / 2
-        const smooth = this.superecllipse(width, height, n)
+        const smooth = this.superellipse(width, height, n)
 
         ctx.fillStyle = "black"
         ctx.setTransform(1, 0, 0, 1, width, height)

--- a/static/posts/smooth-corners/paint.js
+++ b/static/posts/smooth-corners/paint.js
@@ -1,38 +1,41 @@
 registerPaint('smooth-corners', class {
     static get inputProperties() {
-        return [
-            '--smooth-corners'
-        ]
+        return ['--smooth-corners']
     }
+
+    superecllipse(a, b, n) {
+        const n2 = 2 / n
+        const steps = 64
+        const step = (2 * Math.PI) / steps
+        const points = t => {
+            const cosT = Math.cos(t)
+            const sinT = Math.sin(t)
+            return {
+                x: Math.abs(cosT) ** n2 * a * Math.sign(cosT),
+                y: Math.abs(sinT) ** n2 * b * Math.sign(sinT)
+            };
+        };
+        return Array.from({ length: steps }, (_, i) => points(i * step))
+    }
+
     paint(ctx, geom, properties) {
-        const c = properties.get('--smooth-corners').toString()
+        const m = properties.get("--smooth-corners").toString() || 4
+        let n = m
+        if (m > 100) n = 100
+        if (m < 0.00000000001) n = 0.00000000001
 
-        ctx.fillStyle = 'black'
+        const width = geom.width / 2
+        const height = geom.height / 2
+        const smooth = this.superecllipse(width, height, n)
 
-        const n = c
-        let m = n
-        if (n > 100) m = 100
-        if (n < 0.00000000001) m = 0.00000000001
-        const r = geom.width / 2
-        const w = geom.width / 2
-        const h = geom.height / 2
+        ctx.fillStyle = "black"
+        ctx.setTransform(1, 0, 0, 1, width, height)
+        ctx.beginPath()
 
-        ctx.beginPath();
-
-        for (let i = 0; i < (2*r+1); i++) {
-            const x = (i-r) + w
-            const y = (Math.pow(Math.abs(Math.pow(r,m)-Math.pow(Math.abs(i-r),m)),1/m)) + h
-
-            if (i == 0)
-                ctx.moveTo(x, y)
-            else
-                ctx.lineTo(x, y)
-        }
-
-        for (let i = (2*r); i < (4*r+1); i++) {
-            const x = (3*r-i) + w
-            const y = (-Math.pow(Math.abs(Math.pow(r,m)-Math.pow(Math.abs(3*r-i),m)),1/m)) + h
-            ctx.lineTo(x, y)
+        for (let i = 0; i < smooth.length; i++) {
+            const { x, y } = smooth[i]
+            if (i === 0) ctx.moveTo(x, y)
+            else ctx.lineTo(x, y)
         }
 
         ctx.closePath()


### PR DESCRIPTION
The Houndini Rocks page for Smooth Corners says it offers slightly better rounded rectangles by drawing a superellipse, however the superellipse implementation used only produces squares when given a non-square element to mask.

This produces visually identical superellipses. Live demo: https://nqgxk.csb.app/

## Visual Diffing

### Existing Implementation

![image](https://user-images.githubusercontent.com/3440094/88615037-f7d0b000-d088-11ea-8b68-b2735b79dd7d.png)

### Proposed Implementation

![chrome_iJRsBqefZd](https://user-images.githubusercontent.com/3440094/88615753-77ab4a00-d08a-11ea-9f99-58e16dfe7e15.png)

### Difference

![image](https://user-images.githubusercontent.com/3440094/88615297-8b09e580-d089-11ea-90bc-f55e8c37cc5a.png)

